### PR TITLE
Openssl compat

### DIFF
--- a/psp-dev-ccp-v5.c
+++ b/psp-dev-ccp-v5.c
@@ -33,6 +33,13 @@
 #include <string.h>
 
 #include <openssl/evp.h>
+
+/* OpenSSL version 1.0.x support */
+# if OPENSSL_VERSION_NUMBER < 0x10100000 // = OpenSSL 1.1.0
+#  define EVP_MD_CTX_new EVP_MD_CTX_create
+#  define EVP_MD_CTX_free EVP_MD_CTX_destroy
+# endif
+
 #include <zlib.h>
 
 /* Missing in zlib.h */

--- a/psp-dev-ccp-v5.c
+++ b/psp-dev-ccp-v5.c
@@ -34,7 +34,7 @@
 
 #include <openssl/evp.h>
 
-/* OpenSSL version 1.0.x support */
+/* OpenSSL version 1.0.x support (see https://www.openssl.org/docs/man1.1.0/man3/EVP_MD_CTX_new.html#HISTORY) */
 # if OPENSSL_VERSION_NUMBER < 0x10100000 // = OpenSSL 1.1.0
 #  define EVP_MD_CTX_new EVP_MD_CTX_create
 #  define EVP_MD_CTX_free EVP_MD_CTX_destroy


### PR DESCRIPTION
Simple change that allows compilation with OpenSSL version 1.0.X.
The only relevant changes in OpenSSL where the renaming of two functions that are used by the emulator ([see here](https://www.openssl.org/docs/man1.1.0/man3/EVP_MD_CTX_new.html#HISTORY)).